### PR TITLE
remove val in check but check for void 0

### DIFF
--- a/path-handler.js
+++ b/path-handler.js
@@ -51,8 +51,8 @@ function parse (state, depth, filter, result, target) {
 function populate (state, depth, filter, result, target) {
   const nextDepth = depth && depth - 1
   state.each((p, key) => {
-    if (!filter || filter(p)) {
-      if ('val' in p) {
+    if (p && (!filter || filter(p))) {
+      if (p.val !== void 0) {
         let val = p.val
         let sendVal
         if (val && val.isBase) {


### PR DESCRIPTION
this is to enable resetting objects in scrapers, to enable multilingual values adm-state-scraper

setting with `{reset: true}` sets val to `undefined`, but does not `delete obs.val`, so my check for `'val' in obs` was broken.